### PR TITLE
Fix parameter names in the `DiffieHellman.Lazy` interface

### DIFF
--- a/src/main/java/com/goterl/lazysodium/interfaces/DiffieHellman.java
+++ b/src/main/java/com/goterl/lazysodium/interfaces/DiffieHellman.java
@@ -42,11 +42,11 @@ public interface DiffieHellman {
         /**
          * Generate a shared key from another user's public key
          * and a secret key.
-         * @param publicKey Another user's public key.
          * @param secretKey A secret key.
+         * @param publicKey Another user's public key.
          * @return Shared secret key.
          */
-        Key cryptoScalarMult(Key publicKey, Key secretKey);
+        Key cryptoScalarMult(Key secretKey, Key publicKey);
 
     }
 


### PR DESCRIPTION
The problem is _only_ in the parameter names and _only_ in the wrapping interface, so there is not much point to complicate this fix too much.

Fixes https://github.com/terl/lazysodium-java/issues/129