### PR TITLE
Prevent memory access errors in many native calls by adding checks

### DIFF
--- a/src/main/java/com/goterl/lazysodium/LazySodium.java
+++ b/src/main/java/com/goterl/lazysodium/LazySodium.java
@@ -406,19 +406,15 @@ public abstract class LazySodium implements
                                 long opsLimit,
                                 NativeLong memLimit,
                                 PwHash.Alg alg) {
+        PwHash.Checker.checkHash(outputHash);
         PwHash.Checker.checkPassword(password);
         PwHash.Checker.checkSalt(salt);
         PwHash.Checker.checkOpsLimit(opsLimit);
         PwHash.Checker.checkMemLimit(memLimit);
 
+        BaseChecker.checkArrayLength("hash bytes", outputHash, outputHashLen);
         BaseChecker.checkArrayLength("password bytes", password, passwordLen);
 
-        if (outputHashLen < 0 || outputHashLen > outputHash.length) {
-            throw new IllegalArgumentException("outputHashLen out of bounds: " + outputHashLen);
-        }
-        if (passwordLen < 0 || passwordLen > password.length) {
-            throw new IllegalArgumentException("passwordLen out of bounds: " + passwordLen);
-        }
         int res = getSodium().crypto_pwhash(outputHash,
                 outputHashLen,
                 password,
@@ -464,6 +460,7 @@ public abstract class LazySodium implements
             throws SodiumException {
         byte[] passwordBytes = bytes(password);
         PwHash.Checker.checkPassword(passwordBytes);
+        PwHash.Checker.checkBetween("lengthOfHash", lengthOfHash, PwHash.BYTES_MIN, PwHash.BYTES_MAX);
         PwHash.Checker.checkSalt(salt);
         PwHash.Checker.checkOpsLimit(opsLimit);
         PwHash.Checker.checkMemLimit(memLimit);

--- a/src/main/java/com/goterl/lazysodium/interfaces/KeyDerivation.java
+++ b/src/main/java/com/goterl/lazysodium/interfaces/KeyDerivation.java
@@ -75,8 +75,8 @@ public interface KeyDerivation {
             return masterKeyLen == KeyDerivation.MASTER_KEY_BYTES;
         }
 
-        public static boolean subKeyIsCorrect(int lengthOfSubkey) {
-            return isBetween(lengthOfSubkey, BYTES_MIN, BYTES_MAX);
+        public static void checkSubKeyLength(int subkeyLen) {
+            checkBetween("subkey length", subkeyLen, BYTES_MIN, BYTES_MAX);
         }
 
         public static boolean contextIsCorrect(int length) {

--- a/src/main/java/com/goterl/lazysodium/interfaces/PwHash.java
+++ b/src/main/java/com/goterl/lazysodium/interfaces/PwHash.java
@@ -70,37 +70,20 @@ public interface PwHash {
 
 
     class Checker extends BaseChecker {
-        public static boolean saltIsCorrect(long saltLen) {
-            return correctLen(saltLen, PwHash.SALTBYTES);
-        }
-        public static boolean passwordIsCorrect(long len) {
-            return isBetween(len, PwHash.PASSWD_MIN, PwHash.PASSWD_MAX);
-        }
-        public static boolean opsLimitIsCorrect(long ops) {
-            return isBetween(ops, PwHash.OPSLIMIT_MIN, PwHash.OPSLIMIT_MAX);
-        }
-        public static boolean memLimitIsCorrect(NativeLong len) {
-            return isBetween(len, PwHash.MEMLIMIT_MIN, PwHash.MEMLIMIT_MAX);
+        public static void checkPassword(byte[] password) {
+            checkBetween("password length", password.length, PwHash.PASSWD_MIN, PwHash.PASSWD_MAX);
         }
 
-        public static boolean checkAll(long passwordBytesLen,
-                                       long saltBytesLen,
-                                       long opsLimit,
-                                       NativeLong memLimit)
-                throws SodiumException {
-            if (!PwHash.Checker.saltIsCorrect(saltBytesLen)) {
-                throw new SodiumException("The salt provided is not the correct length.");
-            }
-            if (!PwHash.Checker.passwordIsCorrect(passwordBytesLen)) {
-                throw new SodiumException("The password provided is not the correct length.");
-            }
-            if (!PwHash.Checker.opsLimitIsCorrect(opsLimit)) {
-                throw new SodiumException("The opsLimit provided is not the correct value.");
-            }
-            if (!PwHash.Checker.memLimitIsCorrect(memLimit)) {
-                throw new SodiumException("The memLimit provided is not the correct value.");
-            }
-            return true;
+        public static void checkSalt(byte[] salt) {
+            checkEqual("salt length", salt.length, SALTBYTES);
+        }
+
+        public static void checkOpsLimit(long opsLimit) {
+            checkBetween("opsLimit", opsLimit, PwHash.OPSLIMIT_MIN, PwHash.OPSLIMIT_MAX);
+        }
+
+        public static void checkMemLimit(NativeLong memLimit) {
+            checkBetween("memLimit", memLimit, PwHash.MEMLIMIT_MIN, PwHash.MEMLIMIT_MAX);
         }
     }
 

--- a/src/main/java/com/goterl/lazysodium/interfaces/PwHash.java
+++ b/src/main/java/com/goterl/lazysodium/interfaces/PwHash.java
@@ -70,6 +70,10 @@ public interface PwHash {
 
 
     class Checker extends BaseChecker {
+        public static void checkHash(byte[] hash) {
+            checkBetween("hash length", hash.length, PwHash.BYTES_MIN, PwHash.BYTES_MAX);
+        }
+
         public static void checkPassword(byte[] password) {
             checkBetween("password length", password.length, PwHash.PASSWD_MIN, PwHash.PASSWD_MAX);
         }

--- a/src/main/java/com/goterl/lazysodium/interfaces/SecretStream.java
+++ b/src/main/java/com/goterl/lazysodium/interfaces/SecretStream.java
@@ -44,8 +44,26 @@ public interface SecretStream {
 
     class Checker extends BaseChecker {
 
-        public static boolean headerCheck(int headerSize) {
-            return headerSize == HEADERBYTES;
+        public static void checkHeader(byte[] header) {
+            checkEqual("secret stream header length", HEADERBYTES, header.length);
+        }
+
+        public static void checkKey(byte[] key) {
+            checkEqual("secret stream key length", KEYBYTES, key.length);
+        }
+
+        public static void checkPush(byte[] message, long messageLen, byte[] cipher) {
+            checkArrayLength("message bytes", message, messageLen);
+            if (cipher.length < messageLen + ABYTES) {
+                throw new IllegalArgumentException("Cipher array too small for messageLen + header");
+            }
+        }
+
+        public static void checkPull(byte[] cipher, long cipherLen, byte[] message) {
+            checkArrayLength("message bytes", cipher, cipherLen);
+            if (message.length < cipherLen - ABYTES) {
+                throw new IllegalArgumentException("Message array too small for cipherLen - header");
+            }
         }
 
     }

--- a/src/main/java/com/goterl/lazysodium/interfaces/SecretStream.java
+++ b/src/main/java/com/goterl/lazysodium/interfaces/SecretStream.java
@@ -95,7 +95,7 @@ public interface SecretStream {
          * Encrypt a {@code message}.
          * @param state State as initialised in cryptoSecretStreamInitPush.
          * @param cipher The resulting cipher of size {@link #ABYTES} + {@code messageLen}.
-         * @param cipherAddr The cipher address will be stored here if not null.
+         * @param cipherLen The length of the resulting cipher will be stored here if not null.
          * @param message The message to encrypt.
          * @param messageLen The message length.
          * @param additionalData Additional data.
@@ -106,7 +106,7 @@ public interface SecretStream {
         boolean cryptoSecretStreamPush(
                 State state,
                 byte[] cipher,
-                long[] cipherAddr,
+                long[] cipherLen,
                 byte[] message,
                 long messageLen,
                 byte[] additionalData,
@@ -119,7 +119,7 @@ public interface SecretStream {
          * but without additional data.
          * @param state State.
          * @param cipher The resulting cipher of size {@link #ABYTES} + {@code messageLen}.
-         * @param cipherAddr The cipher address will be stored here if not null.
+         * @param cipherLen The length of the resulting cipher will be stored here if not null.
          * @param message The message to encrypt.
          * @param messageLen The message length.
          * @param tag The tag.
@@ -128,7 +128,7 @@ public interface SecretStream {
         boolean cryptoSecretStreamPush(
                 State state,
                 byte[] cipher,
-                long[] cipherAddr,
+                long[] cipherLen,
                 byte[] message,
                 long messageLen,
                 byte tag
@@ -171,8 +171,8 @@ public interface SecretStream {
          * Decrypt a message.
          * @param state The state as put into cryptoSecretStreamInitPull.
          * @param message The message of size {@code cipherLen} - {@link #ABYTES}.
-         * @param messageAddress The place to store the message.
-         * @param tag The tag.
+         * @param messageLen The length of the resulting message will be stored here if not null.
+         * @param tag The received tag will be stored here if not null.
          * @param cipher The resulting encrypted message.
          * @param cipherLen The cipher length.
          * @param additionalData Any authenticated data.
@@ -182,7 +182,7 @@ public interface SecretStream {
         boolean cryptoSecretStreamPull(
                 State state,
                 byte[] message,
-                long[] messageAddress,
+                long[] messageLen,
                 byte[] tag,
                 byte[] cipher,
                 long cipherLen,
@@ -194,7 +194,7 @@ public interface SecretStream {
          * Decrypt a message without additional data.
          * @param state The state as put into cryptoSecretStreamInitPull.
          * @param message The message of size {@code cipherLen} - {@link #ABYTES}.
-         * @param tag The tag.
+         * @param tag The received tag will be stored here if not null.
          * @param cipher The resulting encrypted message.
          * @param cipherLen The cipher length.
          * @return True if successful decryption.

--- a/src/main/java/com/goterl/lazysodium/utils/BaseChecker.java
+++ b/src/main/java/com/goterl/lazysodium/utils/BaseChecker.java
@@ -12,17 +12,55 @@ import com.sun.jna.NativeLong;
 
 public class BaseChecker {
 
+    public static void checkBetween(String name, long num, long min, long max) {
+        if (num < min) {
+            throw new IllegalArgumentException("Provided " + name + " is below minimum bound.");
+        }
+        if (num > max) {
+            throw new IllegalArgumentException("Provided " + name + " is above maximum bound.");
+        }
+    }
+
+    public static void checkBetween(String name, NativeLong num, NativeLong min, NativeLong max) {
+        checkBetween(name, num.longValue(), min.longValue(), max.longValue());
+    }
+
     public static boolean isBetween(long num, long min, long max) {
         return min <= num && num <= max;
     }
 
-    public static boolean isBetween(NativeLong num, NativeLong min, NativeLong max) {
-        long number = num.longValue();
-        return min.longValue() <= number && number <= max.longValue();
-    }
-
     public static boolean correctLen(long num, long len) {
         return num == len;
+    }
+
+    /**
+     * Throw if provided value does not match an expected value.
+     */
+    public static void checkEqual(String name, int expected, int actual) {
+        if (actual != expected) {
+            // Neither value is reported, in case this is passed sensitive
+            // values, even though most uses are likely for header lengths and
+            // similar.
+            throw new IllegalArgumentException(
+                "Provided " + name + " did not match expected value");
+        }
+    }
+
+    public static void checkArrayLength(String name, char[] array, long length) {
+        checkArrayLength(name, array.length, length);
+    }
+
+    public static void checkArrayLength(String name, byte[] array, long length) {
+        checkArrayLength(name, array.length, length);
+    }
+
+    private static void checkArrayLength(String name, int arrayLength, long length) {
+        if (length > arrayLength) {
+            throw new IllegalArgumentException("Provided " + name + " array length is larger than array");
+        }
+        if (length < 0) {
+            throw new IllegalArgumentException("Provided " + name + " array length is negative");
+        }
     }
 
 }

--- a/src/main/java/com/goterl/lazysodium/utils/BaseChecker.java
+++ b/src/main/java/com/goterl/lazysodium/utils/BaseChecker.java
@@ -25,6 +25,12 @@ public class BaseChecker {
         checkBetween(name, num.longValue(), min.longValue(), max.longValue());
     }
 
+    public static void checkAtLeast(String name, long num, long min) {
+        if (num < min) {
+            throw new IllegalArgumentException("Provided " + name + " is below minimum bound.");
+        }
+    }
+
     public static boolean isBetween(long num, long min, long max) {
         return min <= num && num <= max;
     }
@@ -54,6 +60,16 @@ public class BaseChecker {
         checkArrayLength(name, array.length, length);
     }
 
+    public static void checkOptionalArrayLength(String name, byte[] array, long length) {
+        if (array == null) {
+            if (length != 0) {
+                throw new IllegalArgumentException("Provided non-zero length for null " + name);
+            }
+        } else {
+            checkArrayLength(name, array.length, length);
+        }
+    }
+
     private static void checkArrayLength(String name, int arrayLength, long length) {
         if (length > arrayLength) {
             throw new IllegalArgumentException("Provided " + name + " array length is larger than array");
@@ -63,4 +79,15 @@ public class BaseChecker {
         }
     }
 
+    public static void checkOptionalOutPointer(String name, byte[] refArray) {
+        if (refArray != null && refArray.length == 0) {
+            throw new IllegalArgumentException("Provided " + name + " must be either null or non-empty");
+        }
+    }
+
+    public static void checkOptionalOutPointer(String name, long[] refArray) {
+        if (refArray != null && refArray.length == 0) {
+            throw new IllegalArgumentException("Provided " + name + " must be either null or non-empty");
+        }
+    }
 }

--- a/src/test/java/com/goterl/lazysodium/AEADTest.java
+++ b/src/test/java/com/goterl/lazysodium/AEADTest.java
@@ -10,6 +10,7 @@ package com.goterl.lazysodium;
 
 import com.goterl.lazysodium.interfaces.AEAD;
 import com.goterl.lazysodium.interfaces.MessageEncoder;
+import com.goterl.lazysodium.utils.BaseChecker;
 import com.goterl.lazysodium.utils.DetachedDecrypt;
 import com.goterl.lazysodium.utils.DetachedEncrypt;
 import com.goterl.lazysodium.utils.HexMessageEncoder;
@@ -17,6 +18,8 @@ import com.goterl.lazysodium.utils.Key;
 import org.junit.jupiter.api.Test;
 
 import javax.crypto.AEADBadTagException;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -37,6 +40,22 @@ public class AEADTest extends BaseTest {
         String decrypted = lazySodium.decrypt(cipher, null, nPub, key, AEAD.Method.CHACHA20_POLY1305);
 
         assertEquals(decrypted, PASSWORD);
+    }
+
+    @Test
+    public void encryptChachaBadAdditionalDataLen() {
+        Key key = lazySodium.keygen(AEAD.Method.CHACHA20_POLY1305);
+        byte[] nPub = lazySodium.nonce(AEAD.CHACHA20POLY1305_NPUBBYTES);
+        byte[] passwordBytes = PASSWORD.getBytes(StandardCharsets.UTF_8);
+        byte[] cipherBytes = new byte[passwordBytes.length + AEAD.CHACHA20POLY1305_ABYTES];
+
+        assertThrows(IllegalArgumentException.class, () -> lazySodium.cryptoAeadChaCha20Poly1305Encrypt(cipherBytes, null, passwordBytes, -1, null, 0,  null, nPub, key.getAsBytes()));
+        assertThrows(IllegalArgumentException.class, () -> lazySodium.cryptoAeadChaCha20Poly1305Encrypt(cipherBytes, null, passwordBytes, passwordBytes.length + 1, null, 0,  null, nPub, key.getAsBytes()));
+        assertThrows(IllegalArgumentException.class, () -> lazySodium.cryptoAeadChaCha20Poly1305Encrypt(new byte[cipherBytes.length - 1], null, passwordBytes, passwordBytes.length, null, 0,  null, nPub, key.getAsBytes()));
+        assertThrows(IllegalArgumentException.class, () -> lazySodium.cryptoAeadChaCha20Poly1305Encrypt(cipherBytes, null, passwordBytes, passwordBytes.length, null, -1,  null, nPub, key.getAsBytes()));
+        assertThrows(IllegalArgumentException.class, () -> lazySodium.cryptoAeadChaCha20Poly1305Encrypt(cipherBytes, null, passwordBytes, passwordBytes.length, null, 1,  null, nPub, key.getAsBytes()));
+        assertThrows(IllegalArgumentException.class, () -> lazySodium.cryptoAeadChaCha20Poly1305Encrypt(cipherBytes, null, passwordBytes, passwordBytes.length, new byte[1], 2,  null, nPub, key.getAsBytes()));
+        assertThrows(IllegalArgumentException.class, () -> lazySodium.cryptoAeadChaCha20Poly1305Encrypt(cipherBytes, new long[0], passwordBytes, passwordBytes.length, null, 0,  null, nPub, key.getAsBytes()));
     }
 
     @Test

--- a/src/test/java/com/goterl/lazysodium/KeyDerivationTest.java
+++ b/src/test/java/com/goterl/lazysodium/KeyDerivationTest.java
@@ -26,6 +26,7 @@ public class KeyDerivationTest extends BaseTest {
     static final byte[] SHORT_CONTEXT = new byte[]{0, 1, 2, 3, 4, 5};
     static final byte[] VALID_KEY = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31};
     static final byte[] OUT_VALID_KEY_VALID_CONTEXT_1 = new byte[]{61, -17, -126, -25, -14, 29, 2, -83, 89, -120, 37, -35, 102, -11, -77, -59};
+    static final String CONTEXT_STR = "Examples";
     private KeyDerivation.Native keyDerivation;
     private KeyDerivation.Lazy keyDerivationLazy;
 
@@ -38,8 +39,7 @@ public class KeyDerivationTest extends BaseTest {
     @Test
     public void keygen() throws SodiumException {
         byte[] masterKey = new byte[KeyDerivation.MASTER_KEY_BYTES];
-        String contextStr = "Examples";
-        byte[] context = lazySodium.bytes(contextStr);
+        byte[] context = lazySodium.bytes(CONTEXT_STR);
         // Create a master key
         keyDerivation.cryptoKdfKeygen(masterKey);
 
@@ -57,7 +57,7 @@ public class KeyDerivationTest extends BaseTest {
         Key skStr2 = keyDerivationLazy.cryptoKdfDeriveFromKey(
                 KeyDerivation.BYTES_MAX,
                 1L,
-                contextStr,
+                CONTEXT_STR,
                 Key.fromBytes(masterKey)
         );
 
@@ -143,6 +143,8 @@ public class KeyDerivationTest extends BaseTest {
 
     @Test
     public void doesntAllowShortSubKey() {
+        assertThrows(IllegalArgumentException.class, () -> keyDerivationLazy.cryptoKdfDeriveFromKey(KeyDerivation.BYTES_MIN - 1, 1, CONTEXT_STR, Key.fromBytes(VALID_KEY)));
+
         assertThrows(IllegalArgumentException.class, () -> {
             byte[] out = new byte[KeyDerivation.BYTES_MIN - 1];
             keyDerivation.cryptoKdfDeriveFromKey(out, out.length, 1L, VALID_CONTEXT, VALID_KEY);
@@ -151,6 +153,8 @@ public class KeyDerivationTest extends BaseTest {
 
     @Test
     public void doesntAllowLongSubKey() {
+        assertThrows(IllegalArgumentException.class, () -> keyDerivationLazy.cryptoKdfDeriveFromKey(KeyDerivation.BYTES_MAX + 1, 1, CONTEXT_STR, Key.fromBytes(VALID_KEY)));
+
         assertThrows(IllegalArgumentException.class, () -> {
             byte[] out = new byte[KeyDerivation.BYTES_MAX + 1];
             keyDerivation.cryptoKdfDeriveFromKey(out, out.length, 1L, VALID_CONTEXT, VALID_KEY);

--- a/src/test/java/com/goterl/lazysodium/ScryptTest.java
+++ b/src/test/java/com/goterl/lazysodium/ScryptTest.java
@@ -1,0 +1,45 @@
+package com.goterl.lazysodium;
+
+import com.goterl.lazysodium.exceptions.SodiumException;
+import com.goterl.lazysodium.interfaces.Scrypt;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ScryptTest extends BaseTest {
+
+    private final String PASSWORD = "Password123456!!!!@@";
+    private final byte[] PASSWORD_BYTES = PASSWORD.getBytes(StandardCharsets.UTF_8);
+    private Scrypt.Lazy scryptLazy;
+
+    @BeforeAll
+    public void before() {
+        scryptLazy = lazySodium;
+    }
+
+    @Test
+    public void scryptHash() throws SodiumException {
+        byte[] salt = new byte[LazySodium.longToInt(Scrypt.SCRYPTSALSA208SHA256_SALT_BYTES)];
+        String scryptHash = scryptLazy.cryptoPwHashScryptSalsa208Sha256(
+                PASSWORD,
+                300L, // This can be anything up to Constants.SIZE_MAX
+                salt,
+                Scrypt.SCRYPTSALSA208SHA256_OPSLIMIT_MIN,
+                Scrypt.SCRYPTSALSA208SHA256_MEMLIMIT_MIN
+        );
+
+        String hash = scryptLazy.cryptoPwHashScryptSalsa208Sha256Str(
+                PASSWORD,
+                Scrypt.SCRYPTSALSA208SHA256_OPSLIMIT_MIN,
+                Scrypt.SCRYPTSALSA208SHA256_MEMLIMIT_MIN
+        );
+
+        boolean isCorrect = scryptLazy.cryptoPwHashScryptSalsa208Sha256StrVerify(hash, PASSWORD);
+
+
+        assertTrue(isCorrect, "Minimum hashing failed.");
+    }
+}

--- a/src/test/java/com/goterl/lazysodium/SecretStreamTest.java
+++ b/src/test/java/com/goterl/lazysodium/SecretStreamTest.java
@@ -11,49 +11,157 @@ package com.goterl.lazysodium;
 import com.goterl.lazysodium.exceptions.SodiumException;
 import com.goterl.lazysodium.interfaces.SecretStream;
 import com.goterl.lazysodium.utils.Key;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SecretStreamTest extends BaseTest {
+    private SecretStream.Lazy secretStreamLazy;
+    private SecretStream.Native secretStreamNative;
 
-    private String message1 = "Arbitrary data to encrypt";
-    private String message2 = "split into";
-    private String message3 = "three messages";
+    private static final String message1 = "Arbitrary data to encrypt";
+    private static final String message2 = "split into";
+    private static final String message3 = "three messages";
+
+
+    @BeforeAll
+    public void before() {
+        secretStreamLazy = lazySodium;
+        secretStreamNative = lazySodium;
+    }
 
     @Test
     public void test1() throws SodiumException {
-        Key key = lazySodium.cryptoSecretStreamKeygen();
+        Key key = secretStreamLazy.cryptoSecretStreamKeygen();
 
-        byte[] header = lazySodium.randomBytesBuf(SecretStream.HEADERBYTES);
+        byte[] header = new byte[SecretStream.HEADERBYTES];
 
         // Start the encryption
-        SecretStream.State state = lazySodium.cryptoSecretStreamInitPush(header, key);
+        SecretStream.State state = secretStreamLazy.cryptoSecretStreamInitPush(header, key);
 
-        String c1 = lazySodium.cryptoSecretStreamPush(state, message1, SecretStream.TAG_MESSAGE);
-        String c2 = lazySodium.cryptoSecretStreamPush(state, message2, SecretStream.TAG_MESSAGE);
-        String c3 = lazySodium.cryptoSecretStreamPush(state, message3, SecretStream.TAG_FINAL);
+        String c1 = secretStreamLazy.cryptoSecretStreamPush(state, message1, SecretStream.TAG_MESSAGE);
+        String c2 = secretStreamLazy.cryptoSecretStreamPush(state, message2, SecretStream.TAG_MESSAGE);
+        String c3 = secretStreamLazy.cryptoSecretStreamPush(state, message3, SecretStream.TAG_FINAL);
 
         // Start the decryption
         byte[] tag = new byte[1];
 
-        SecretStream.State state2 = lazySodium.cryptoSecretStreamInitPull(header, key);
+        SecretStream.State state2 = secretStreamLazy.cryptoSecretStreamInitPull(header, key);
 
-        String decryptedMessage = lazySodium.cryptoSecretStreamPull(state2, c1, tag);
-        String decryptedMessage2 = lazySodium.cryptoSecretStreamPull(state2, c2, tag);
-        String decryptedMessage3 = lazySodium.cryptoSecretStreamPull(state2, c3, tag);
+        String decryptedMessage = secretStreamLazy.cryptoSecretStreamPull(state2, c1, tag);
+        String decryptedMessage2 = secretStreamLazy.cryptoSecretStreamPull(state2, c2, tag);
+        String decryptedMessage3 = secretStreamLazy.cryptoSecretStreamPull(state2, c3, tag);
 
-        if (tag[0] == SecretStream.XCHACHA20POLY1305_TAG_FINAL) {
-            assertTrue(
-                    decryptedMessage.equals(message1) &&
-                    decryptedMessage2.equals(message2) &&
-                    decryptedMessage3.equals(message3)
-            );
-        }
+        assertEquals(SecretStream.XCHACHA20POLY1305_TAG_FINAL, tag[0]);
 
+        assertEquals(message1, decryptedMessage);
+        assertEquals(message2, decryptedMessage2);
+        assertEquals(message3, decryptedMessage3);
     }
 
+    @Test
+    public void testInvalidKeySize() {
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamKeygen(new byte[SecretStream.KEYBYTES - 1]));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamKeygen(new byte[SecretStream.KEYBYTES + 1]));
+    }
 
+    @Test
+    public void testStreamKeyGenChecks() {
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamKeygen(new byte[SecretStream.KEYBYTES - 1]));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamKeygen(new byte[SecretStream.KEYBYTES + 1]));
+    }
 
+    @Test
+    public void testInitPushChecks() {
+        Key goodKey = secretStreamLazy.cryptoSecretStreamKeygen();
 
+        assertThrows(IllegalArgumentException.class, () -> secretStreamLazy.cryptoSecretStreamInitPush(new byte[SecretStream.HEADERBYTES - 1], goodKey));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamLazy.cryptoSecretStreamInitPush(new byte[SecretStream.HEADERBYTES + 1], goodKey));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamLazy.cryptoSecretStreamInitPush(new byte[SecretStream.HEADERBYTES], Key.fromBytes(new byte[SecretStream.KEYBYTES - 1])));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamLazy.cryptoSecretStreamInitPush(new byte[SecretStream.HEADERBYTES], Key.fromBytes(new byte[SecretStream.KEYBYTES + 1])));
+
+        SecretStream.State state = new SecretStream.State();
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamInitPush(state, new byte[SecretStream.HEADERBYTES - 1], goodKey.getAsBytes()));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamInitPush(state, new byte[SecretStream.HEADERBYTES + 1], goodKey.getAsBytes()));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamInitPush(state, new byte[SecretStream.HEADERBYTES], new byte[SecretStream.KEYBYTES - 1]));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamInitPush(state, new byte[SecretStream.HEADERBYTES], new byte[SecretStream.KEYBYTES + 1]));
+    }
+
+    @Test
+    public void testPushChecks() throws SodiumException {
+        byte[] header = new byte[SecretStream.HEADERBYTES];
+        Key key = secretStreamLazy.cryptoSecretStreamKeygen();
+
+        SecretStream.State state = secretStreamLazy.cryptoSecretStreamInitPush(header, key);
+        byte[] message = message1.getBytes(StandardCharsets.UTF_8);
+        byte[] cipherBuf = new byte[message.length + SecretStream.ABYTES];
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, cipherBuf, null, message, -1, (byte) 0));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, cipherBuf, null, message, message.length + 1, (byte) 0));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, new byte[cipherBuf.length - 1], null, message, message.length, (byte) 0));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, cipherBuf, new long[0], message, message.length, (byte) 0));
+
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, cipherBuf, message, -1, (byte) 0));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, cipherBuf, message, message.length + 1, (byte) 0));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, new byte[cipherBuf.length - 1], message, message.length, (byte) 0));
+
+        byte[] additionalData = new byte[100];
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, cipherBuf, null, message, -1, additionalData, additionalData.length, (byte) 0));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, cipherBuf, null, message, message.length + 1, additionalData, additionalData.length, (byte) 0));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, new byte[cipherBuf.length - 1], null, message, message.length, additionalData, additionalData.length, (byte) 0));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, cipherBuf, new long[0], message, message.length, additionalData, additionalData.length, (byte) 0));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, cipherBuf, null, message, message.length, additionalData, -1, (byte) 0));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, cipherBuf, null, message, message.length, additionalData, additionalData.length + 1, (byte) 0));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPush(state, cipherBuf, null, message, message.length, null, additionalData.length, (byte) 0));
+    }
+
+    @Test
+    public void testInitPullChecks() {
+        Key goodKey = secretStreamLazy.cryptoSecretStreamKeygen();
+
+        assertThrows(IllegalArgumentException.class, () -> secretStreamLazy.cryptoSecretStreamInitPull(new byte[SecretStream.HEADERBYTES - 1], goodKey));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamLazy.cryptoSecretStreamInitPull(new byte[SecretStream.HEADERBYTES + 1], goodKey));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamLazy.cryptoSecretStreamInitPull(new byte[SecretStream.HEADERBYTES], Key.fromBytes(new byte[SecretStream.KEYBYTES - 1])));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamLazy.cryptoSecretStreamInitPull(new byte[SecretStream.HEADERBYTES], Key.fromBytes(new byte[SecretStream.KEYBYTES + 1])));
+
+        SecretStream.State state = new SecretStream.State();
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamInitPull(state, new byte[SecretStream.HEADERBYTES - 1], goodKey.getAsBytes()));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamInitPull(state, new byte[SecretStream.HEADERBYTES + 1], goodKey.getAsBytes()));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamInitPull(state, new byte[SecretStream.HEADERBYTES], new byte[SecretStream.KEYBYTES - 1]));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamInitPull(state, new byte[SecretStream.HEADERBYTES], new byte[SecretStream.KEYBYTES + 1]));
+    }
+
+    @Test
+    public void testPullChecks() throws SodiumException {
+        byte[] header = new byte[SecretStream.HEADERBYTES];
+        Key key = secretStreamLazy.cryptoSecretStreamKeygen();
+
+        SecretStream.State state = secretStreamLazy.cryptoSecretStreamInitPull(header, key);
+        byte[] message = message1.getBytes(StandardCharsets.UTF_8);
+        byte[] cipher = new byte[message.length + SecretStream.ABYTES];
+        byte[] messageBuf = new byte[message.length];
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPull(state, messageBuf, null, cipher, -1));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPull(state, messageBuf, null, cipher, cipher.length + 1));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPull(state, new byte[messageBuf.length - 1], null, cipher, cipher.length));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPull(state, messageBuf, new byte[0], cipher, cipher.length));
+
+        byte[] additionalData = new byte[100];
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPull(state, messageBuf, null, null, cipher, -1, additionalData, additionalData.length));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPull(state, messageBuf, null, null, cipher, cipher.length + 1, additionalData, additionalData.length));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPull(state, new byte[messageBuf.length - 1], null, null, cipher, cipher.length, additionalData, additionalData.length));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPull(state, messageBuf, null, new byte[0], cipher, cipher.length, additionalData, additionalData.length));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPull(state, messageBuf, null, null, cipher, cipher.length, additionalData, -1));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPull(state, messageBuf, null, null, cipher, cipher.length, additionalData, additionalData.length + 1));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPull(state, messageBuf, null, null, cipher, cipher.length, null, additionalData.length));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamNative.cryptoSecretStreamPull(state, messageBuf, new long[0], null, cipher, cipher.length, additionalData, additionalData.length));
+
+        assertThrows(IllegalArgumentException.class, () -> secretStreamLazy.cryptoSecretStreamPull(state, "", null));
+        String cipherString = lazySodium.encodeToString(cipher);
+        assertThrows(IllegalArgumentException.class, () -> secretStreamLazy.cryptoSecretStreamPull(state, cipherString.substring(cipherString.length() - 2), null));
+        assertThrows(IllegalArgumentException.class, () -> secretStreamLazy.cryptoSecretStreamPull(state, cipherString, new byte[0]));
+    }
 }


### PR DESCRIPTION
Fix from https://github.com/terl/lazysodium-java/pull/95, rebased, enlarged and improved, added corresponding unit tests.

Still, this is still very much _not_ a complete coverage. Many more checks are needed.