### PR TITLE
Refuse to decode invalid hex strings in `sodiumHex2Bin`

### DIFF
--- a/src/main/java/com/goterl/lazysodium/LazySodium.java
+++ b/src/main/java/com/goterl/lazysodium/LazySodium.java
@@ -134,15 +134,29 @@ public abstract class LazySodium implements
         return new String(hexChars);
     }
 
-    // The following is from https://stackoverflow.com/a/140861/3526705
     private static byte[] hexToBytes(String s) {
         int len = s.length();
+        if (len % 2 != 0) {
+            throw new IllegalArgumentException("Hexadecimal string length must be even");
+        }
         byte[] data = new byte[len / 2];
-        for (int i = 0; i < len; i += 2) {
-            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
-                    + Character.digit(s.charAt(i + 1), 16));
+        for (int i = 0; i < data.length; ++i) {
+            data[i] = (byte)(hexDigit(s.charAt(2 * i)) << 4 | hexDigit(s.charAt(2 * i + 1)));
         }
         return data;
+    }
+
+    private static byte hexDigit(char c) {
+        if (c >= '0' && c <= '9') {
+            return (byte)(c - '0');
+        }
+        if (c >= 'A' && c <= 'F') {
+            return (byte)(c - 'A' + 10);
+        }
+        if (c >= 'a' && c <= 'f') {
+            return (byte)(c - 'a' + 10);
+        }
+        throw new IllegalArgumentException("Illegal hexadecimal character " + (byte)(c));
     }
 
 

--- a/src/test/java/com/goterl/lazysodium/LazySodiumTest.java
+++ b/src/test/java/com/goterl/lazysodium/LazySodiumTest.java
@@ -1,0 +1,19 @@
+package com.goterl.lazysodium;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class LazySodiumTest extends BaseTest {
+    @Test
+    public void toBinary() {
+        assertArrayEquals(new byte[0], lazySodium.sodiumHex2Bin(""));
+        assertArrayEquals(new byte[]{0x01, 0x02, (byte) 0xFE, (byte) 0x80, 0x7F}, lazySodium.sodiumHex2Bin("0102FE807F"));
+
+        assertThrows(IllegalArgumentException.class, () -> lazySodium.sodiumHex2Bin("A"));
+        assertThrows(IllegalArgumentException.class, () -> lazySodium.sodiumHex2Bin("333"));
+        assertThrows(IllegalArgumentException.class, () -> lazySodium.sodiumHex2Bin("33AX"));
+        assertThrows(IllegalArgumentException.class, () -> lazySodium.sodiumHex2Bin("01-23"));
+    }
+}

--- a/src/test/java/com/goterl/lazysodium/ShortHashTest.java
+++ b/src/test/java/com/goterl/lazysodium/ShortHashTest.java
@@ -12,6 +12,8 @@ import com.goterl.lazysodium.exceptions.SodiumException;
 import com.goterl.lazysodium.utils.Key;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ShortHashTest extends BaseTest {
@@ -22,7 +24,7 @@ public class ShortHashTest extends BaseTest {
         String hashThis = "This should get hashed";
 
         Key key = lazySodium.cryptoShortHashKeygen();
-        String hash = lazySodium.cryptoShortHash(hashThis, key);
+        String hash = lazySodium.cryptoShortHash(lazySodium.toHexStr(hashThis.getBytes(StandardCharsets.UTF_8)), key);
 
         assertNotNull(hash);
     }


### PR DESCRIPTION
Fixes https://github.com/terl/lazysodium-java/issues/128