### PR TITLE
Breaking change: ShortHash interface, added argument checks, test

### DIFF
--- a/src/main/java/com/goterl/lazysodium/LazySodium.java
+++ b/src/main/java/com/goterl/lazysodium/LazySodium.java
@@ -2020,22 +2020,23 @@ public abstract class LazySodium implements
 
     @Override
     public boolean cryptoShortHash(byte[] out, byte[] in, long inLen, byte[] key) {
-        if (inLen < 0 || inLen > in.length) {
-            throw new IllegalArgumentException("inLen out of bounds: " + inLen);
-        }
+        BaseChecker.checkArrayLength("in", in, inLen);
+        ShortHash.Checker.checkHash(out);
+        ShortHash.Checker.checkKey(key);
         return successful(getSodium().crypto_shorthash(out, in, inLen, key));
     }
 
     @Override
     public void cryptoShortHashKeygen(byte[] k) {
+        ShortHash.Checker.checkKey(k);
         getSodium().crypto_shorthash_keygen(k);
     }
 
     @Override
-    public String cryptoShortHash(String in, Key key) throws SodiumException {
-        byte[] inBytes = hexToBytes(in);
+    public String cryptoShortHash(byte[] inBytes, Key key) throws SodiumException {
         byte[] keyBytes = key.getAsBytes();
-        byte[] out = randomBytesBuf(ShortHash.BYTES);
+        ShortHash.Checker.checkKey(keyBytes);
+        byte[] out = new byte[ShortHash.BYTES];
         if (getSodium().crypto_shorthash(out, inBytes, inBytes.length, keyBytes) != 0) {
             throw new SodiumException("Failed short-input hashing.");
         }
@@ -2043,8 +2044,18 @@ public abstract class LazySodium implements
     }
 
     @Override
+    public String cryptoShortHashStr(String in, Key key) throws SodiumException {
+        return cryptoShortHash(bytes(in), key);
+    }
+
+    @Override
+    public String cryptoShortHashHex(String hexIn, Key key) throws SodiumException {
+        return cryptoShortHash(hexToBytes(hexIn), key);
+    }
+
+    @Override
     public Key cryptoShortHashKeygen() {
-        byte[] key = randomBytesBuf(ShortHash.SIPHASH24_KEYBYTES);
+        byte[] key = randomBytesBuf(ShortHash.KEYBYTES);
         getSodium().crypto_shorthash_keygen(key);
         return Key.fromBytes(key);
     }

--- a/src/main/java/com/goterl/lazysodium/Sodium.java
+++ b/src/main/java/com/goterl/lazysodium/Sodium.java
@@ -694,7 +694,7 @@ public class Sodium {
 
     public native int crypto_shorthash(byte[] out, byte[] in, long inLen, byte[] key);
 
-    public native int crypto_shorthash_keygen(byte[] key);
+    public native void crypto_shorthash_keygen(byte[] key);
 
 
 

--- a/src/main/java/com/goterl/lazysodium/interfaces/Base.java
+++ b/src/main/java/com/goterl/lazysodium/interfaces/Base.java
@@ -48,7 +48,7 @@ public interface Base {
 
 
     /**
-     * Convert a string to directly bytes.
+     * Convert a string to bytes using the configured charset.
      * @param s The String to convert to a byte array.
      * @return A byte array from {@code s}.
      */

--- a/src/main/java/com/goterl/lazysodium/interfaces/ShortHash.java
+++ b/src/main/java/com/goterl/lazysodium/interfaces/ShortHash.java
@@ -10,7 +10,9 @@ package com.goterl.lazysodium.interfaces;
 
 
 import com.goterl.lazysodium.exceptions.SodiumException;
+import com.goterl.lazysodium.utils.BaseChecker;
 import com.goterl.lazysodium.utils.Key;
+import com.sun.jna.NativeLong;
 
 public interface ShortHash {
 
@@ -22,6 +24,16 @@ public interface ShortHash {
         BYTES = SIPHASH24_BYTES,
         KEYBYTES = SIPHASH24_KEYBYTES;
 
+
+    class Checker extends BaseChecker {
+        public static void checkHash(byte[] hash) {
+            checkEqual("hash length", hash.length, BYTES);
+        }
+
+        public static void checkKey(byte[] key) {
+            checkEqual("key length", key.length, KEYBYTES);
+        }
+    }
 
 
     interface Native {
@@ -50,7 +62,7 @@ public interface ShortHash {
 
         /**
          * Generate a 64-bit key for short-input hashing.
-         * @return Key in string format.
+         * @return Key.
          */
         Key cryptoShortHashKeygen();
 
@@ -58,9 +70,25 @@ public interface ShortHash {
          * Hash a short message using a key.
          * @param in The short message to hash.
          * @param key The key generated via {@link #cryptoShortHashKeygen()}.
-         * @return Your message hashed of size {@link #BYTES}.
+         * @return Your message hashed of size {@link #BYTES}, as hexadecimal string.
          */
-        String cryptoShortHash(String in, Key key) throws SodiumException;
+        String cryptoShortHash(byte[] in, Key key) throws SodiumException;
+
+        /**
+         * Hash a short string using a key.
+         * @param in The short message to hash.
+         * @param key The key generated via {@link #cryptoShortHashKeygen()}.
+         * @return Your message hashed of size {@link #BYTES}, as hexadecimal string.
+         */
+        String cryptoShortHashStr(String in, Key key) throws SodiumException;
+
+        /**
+         * Hash a short hexadecimal string using a key.
+         * @param hexIn The short message to hash, represented as hexadecimal string.
+         * @param key The key generated via {@link #cryptoShortHashKeygen()}.
+         * @return Your message hashed of size {@link #BYTES}, as hexadecimal string.
+         */
+        String cryptoShortHashHex(String hexIn, Key key) throws SodiumException;
 
 
     }

--- a/src/test/java/com/goterl/lazysodium/ShortHashTest.java
+++ b/src/test/java/com/goterl/lazysodium/ShortHashTest.java
@@ -9,26 +9,91 @@
 package com.goterl.lazysodium;
 
 import com.goterl.lazysodium.exceptions.SodiumException;
+import com.goterl.lazysodium.interfaces.ShortHash;
 import com.goterl.lazysodium.utils.Key;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ShortHashTest extends BaseTest {
 
+    private static final String HASHED_MESSAGE = "This should get hashed";
+    private static final String CORRECT_MESSAGE_HASH = "9B680E20E9486A40";
 
-    @Test
-    public void hash() throws SodiumException {
-        String hashThis = "This should get hashed";
+    private ShortHash.Lazy shortHashLazy;
+    private ShortHash.Native shortHashNative;
 
-        Key key = lazySodium.cryptoShortHashKeygen();
-        String hash = lazySodium.cryptoShortHash(lazySodium.toHexStr(hashThis.getBytes(StandardCharsets.UTF_8)), key);
-
-        assertNotNull(hash);
+    @BeforeAll
+    public void before() {
+        shortHashLazy = lazySodium;
+        shortHashNative = lazySodium;
     }
 
+    @Test
+    public void cryptoShortHashKeygen() {
+        Key key = shortHashLazy.cryptoShortHashKeygen();
+        assertNotNull(key);
+        assertEquals(ShortHash.KEYBYTES, key.getAsBytes().length);
 
+        byte[] keyBytes = new byte[ShortHash.KEYBYTES];
+        shortHashNative.cryptoShortHashKeygen(keyBytes);
+    }
+
+    @Test
+    public void rejectShortKeyBuffer() {
+        assertThrows(IllegalArgumentException.class, () -> shortHashNative.cryptoShortHashKeygen(new byte[ShortHash.KEYBYTES - 1]));
+        assertThrows(IllegalArgumentException.class, () -> shortHashNative.cryptoShortHashKeygen(new byte[ShortHash.KEYBYTES + 1]));
+    }
+
+    @Test
+    public void cryptoShortHashStr() throws SodiumException {
+        Key key = Key.fromBytes(new byte[ShortHash.KEYBYTES]);
+        String hashFromString = shortHashLazy.cryptoShortHashStr(HASHED_MESSAGE, key);
+        assertEquals(CORRECT_MESSAGE_HASH, hashFromString);
+    }
+
+    @Test
+    public void cryptoShortHashHex() throws SodiumException {
+        Key key = Key.fromBytes(new byte[ShortHash.KEYBYTES]);
+        String hashFromHex = shortHashLazy.cryptoShortHashHex(lazySodium.toHexStr(HASHED_MESSAGE.getBytes(StandardCharsets.UTF_8)), key);
+        assertEquals(CORRECT_MESSAGE_HASH, hashFromHex);
+    }
+
+    @Test
+    public void cryptoShortHash() throws SodiumException {
+        Key key = Key.fromBytes(new byte[ShortHash.KEYBYTES]);
+        String hashFromBytes = shortHashLazy.cryptoShortHash(HASHED_MESSAGE.getBytes(StandardCharsets.UTF_8), key);
+        assertEquals(CORRECT_MESSAGE_HASH, hashFromBytes);
+    }
+
+    @Test
+    public void cryptoShortHashNative() {
+        byte[] inBytes = HASHED_MESSAGE.getBytes(StandardCharsets.UTF_8);
+        byte[] out = new byte[ShortHash.BYTES];
+        boolean result = shortHashNative.cryptoShortHash(out, inBytes, inBytes.length, new byte[ShortHash.KEYBYTES]);
+        assertTrue(result);
+        assertEquals(CORRECT_MESSAGE_HASH, lazySodium.toHexStr(out));
+    }
+
+    @Test
+    public void hashChecks() {
+        byte[] key = new byte[ShortHash.KEYBYTES - 1];
+        assertThrows(IllegalArgumentException.class, () -> shortHashLazy.cryptoShortHash(HASHED_MESSAGE.getBytes(StandardCharsets.UTF_8), Key.fromBytes(key)));
+        assertThrows(IllegalArgumentException.class, () -> shortHashLazy.cryptoShortHash(HASHED_MESSAGE.getBytes(StandardCharsets.UTF_8), Key.fromBytes(new byte[ShortHash.KEYBYTES + 1])));
+
+        byte[] inBytes = HASHED_MESSAGE.getBytes(StandardCharsets.UTF_8);
+        assertThrows(IllegalArgumentException.class, () -> shortHashNative.cryptoShortHash(new byte[ShortHash.BYTES - 1], inBytes, inBytes.length, key));
+        assertThrows(IllegalArgumentException.class, () -> shortHashNative.cryptoShortHash(new byte[ShortHash.BYTES + 1], inBytes, inBytes.length, key));
+        byte[] out = new byte[ShortHash.BYTES];
+        assertThrows(IllegalArgumentException.class, () -> shortHashNative.cryptoShortHash(out, inBytes, inBytes.length + 1, key));
+        assertThrows(IllegalArgumentException.class, () -> shortHashNative.cryptoShortHash(out, inBytes, inBytes.length, new byte[ShortHash.KEYBYTES - 1]));
+        assertThrows(IllegalArgumentException.class, () -> shortHashNative.cryptoShortHash(out, inBytes, inBytes.length, new byte[ShortHash.KEYBYTES + 1]));
+    }
 
 }


### PR DESCRIPTION
* breaking change: confusing behavior of `cryptoShortHash` expecting a hexadecimal string (together with the previous behavior of silently accepting non-hexadecimal characters!) was a footgun. Changed to explicitly distinguish `cryptoShortHashStr` and `cryptoShortHashHex`.
* added argument checks
* unit test
+ fix native signature (the function returns void, not int)

Fixes https://github.com/terl/lazysodium-java/issues/117